### PR TITLE
Create method to get max bounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ var img = [
   3101   // original height of image
 ]
 // create the map
-var map = L.map('map')
+var map = L.map('map', {
+  crs: L.CRS.Simple
+})
 
 // assign map and image dimensions
 var rc = new L.RasterCoords(map, img)
@@ -42,7 +44,9 @@ map.on('click', function (event) {
 
 // the tile layer containing the image generated with `gdal2tiles --leaflet -p raster -w none <img> tiles`
 L.tileLayer('./tiles/{z}/{x}/{y}.png', {
-  noWrap: true
+  noWrap: true,
+  bounds: rc.getMaxBounds(),
+  maxNativeZoom: rc.zoomLevel(),
 }).addTo(map)
 ```
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ map.on('click', function (event) {
 L.tileLayer('./tiles/{z}/{x}/{y}.png', {
   noWrap: true,
   bounds: rc.getMaxBounds(),
-  maxNativeZoom: rc.zoomLevel(),
+  maxNativeZoom: rc.zoomLevel()
 }).addTo(map)
 ```
 

--- a/example/index.js
+++ b/example/index.js
@@ -16,6 +16,7 @@
 
     // create the map
     var map = L.map(mapid, {
+      crs: L.CRS.Simple,
       minZoom: minZoom,
       maxZoom: maxZoom
     })
@@ -38,6 +39,8 @@
     // the tile layer containing the image generated with gdal2tiles --leaflet ...
     L.tileLayer('./tiles/{z}/{x}/{y}.png', {
       noWrap: true,
+      bounds: rc.getMaxBounds(),
+      maxNativeZoom: rc.zoomLevel(),
       attribution: 'Map <a href="https://commons.wikimedia.org/wiki/' +
         'File:Karta_%C3%B6ver_Europa,_1672_-_Skoklosters_slott_-_95177.tif">' +
         'Karta över Europa, 1672 - Skoklosters</a> under ' +

--- a/rastercoords.js
+++ b/rastercoords.js
@@ -68,12 +68,19 @@
       return this.map.project(coords, this.zoom)
     },
     /**
+     * get the max bounds of the image
+     */
+    getMaxBounds: function () {
+      var southWest = this.unproject([0, this.height])
+      var northEast = this.unproject([this.width, 0])
+      return new L.LatLngBounds(southWest, northEast);
+    },
+    /**
      * sets the max bounds on map
      */
     setMaxBounds: function () {
-      var southWest = this.unproject([0, this.height])
-      var northEast = this.unproject([this.width, 0])
-      this.map.setMaxBounds(new L.LatLngBounds(southWest, northEast))
+      const bounds = this.getMaxBounds();
+      this.map.setMaxBounds(bounds)
     }
   }
 


### PR DESCRIPTION
Hi, thanks for plugin
Aim of this PR is to address the issues #7 and #9 by adding `crs` and `getMaxBounds` (new method) to examples

To prevent fetching the tiles outside of the image, the bounds can be obtained from rc object
Also, looks like the map bounds are not 100% correct without `crs: L.CRS.Simple` map property. For example, if the image is tall, it gets cropped at the bottom
without crs: https://codesandbox.io/s/eloquent-tree-0htxi?file=/scripts.js
with crs: https://codesandbox.io/s/boring-banach-o7nk0?file=/scripts.js


